### PR TITLE
feat: first shot for securityonion terraform

### DIFF
--- a/terraform/public_subnet.tf
+++ b/terraform/public_subnet.tf
@@ -79,3 +79,106 @@ resource "aws_eip" "cribl_server_eip" {
     Project = var.PROJECT_PREFIX
   }
 }
+
+############################################ Logging/SecurityOnion Server ############################################
+resource "aws_security_group" "securityonion_server_sg2" {
+  vpc_id      = module.vpc.vpc_id
+  description = "SecurityOnion security group"
+  tags = {
+    Name    = "${var.PROJECT_PREFIX}_securityonion_server_sg2"
+    Project = var.PROJECT_PREFIX
+  }
+
+  # Allow ICMP from jumpbox
+  ingress {
+    description = "Allow ICMP from management subnet"
+    from_port   = 8
+    to_port     = 0
+    protocol    = "icmp"
+    cidr_blocks = ["${module.teleport.private_ip_addr}/32"]
+  }
+
+  # Allow SSH from jumpbox
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["${module.teleport.private_ip_addr}/32"]
+  }
+
+  # HTTP port for Web UI
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+    cidr_blocks = [
+      "${module.teleport.private_ip_addr}/32",
+    ]
+  }
+
+  # HTTPS port for Web UI
+  ingress {
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+    cidr_blocks = [
+      "${module.teleport.private_ip_addr}/32",
+    ]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "securityonion_server" {
+  ami           = var.securityonion-ami
+  instance_type = "t3.medium"
+  # Docs prod recommendation - https://docs.securityonion.net/en/2.3/cloud-ami.html
+  # instance_type           = "t3a.xlarge"
+  subnet_id               = aws_subnet.logging.id
+  vpc_security_group_ids  = [aws_security_group.securityonion_server_sg2.id]
+  key_name                = "${var.PROJECT_PREFIX}-ssh-key"
+  private_ip              = var.logging_subnet_map["cribl"]
+  disable_api_termination = true
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size           = 150
+    volume_type           = "gp2"
+    delete_on_termination = true
+    encrypted             = true
+  }
+
+  ################## DO NOT TOUCH ##################
+  ############# IGNORE instance type ###############
+  lifecycle {
+    ignore_changes = [
+      instance_type,
+      instance_state,
+      cpu_core_count,
+      ebs_optimized,
+    ]
+  }
+  ############# IGNORE instance type ###############
+  ################## DO NOT TOUCH ##################
+
+  tags = {
+    Name    = "${var.PROJECT_PREFIX}_securityonion_server"
+    Project = var.PROJECT_PREFIX
+  }
+}
+
+resource "aws_eip" "securityonion_server_eip" {
+  instance = aws_instance.securityonion_server.id
+  vpc      = true
+  tags = {
+    Name    = "${var.PROJECT_PREFIX}_securityonion_server_eip"
+    Project = var.PROJECT_PREFIX
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -66,7 +66,8 @@ variable "logging_cidr_block" {
 variable "logging_subnet_map" {
   type = map(string)
   default = {
-    "cribl" = "172.16.22.10",
+    "cribl"         = "172.16.22.10",
+    "securityonion" = "172.16.22.23",
   }
 }
 ######################## Prod subnet ########################
@@ -135,6 +136,13 @@ variable "windows-ami" {
   description = "Microsoft Windows Server 2022 Base"
   type        = string
   default     = "ami-0ae8d60635de460b2"
+}
+
+variable "securityonion-ami" {
+  # https://aws.amazon.com/marketplace/pp/prodview-4gpqv3qlxq4ww?ref=_ptnr_soc_docs_210505
+  description = "Security Onion 2"
+  type        = string
+  default     = ""
 }
 
 ######################## Teleport ########################


### PR DESCRIPTION
# Background
Security Onion server

* Requires to subscribe to securityonion ami that is used here and update matching reference in variables - https://aws.amazon.com/marketplace/pp/prodview-4gpqv3qlxq4ww?ref=_ptnr_soc_docs_210505#pdp-pricing
* only default ami setup. extra configuration needed depending on requirements
* t3.medium. to scale up/down as needed

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Changes

* Terraform setup for security onion

# Testing
Per pipeline, Next when deploying.