### PR TITLE
add few helper ansible playbooks to list/turn on/off ec2 instances an…

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ pip install -r requirements.txt
 ansible-galaxy install -r requirements.yml
 ansible-playbook -v <playbook.yml>
 ```
+For ansible with amazon resources
+```
+export AWS_ACCESS_KEY_ID=REDACTED
+export AWS_SECRET_ACCESS_KEY=REDACTED
+ansible-playbook -v amazon_logging_off.yml
+```
+with hosts.ini entry. interpreter part only needed if virtualenv.
+```
+localhost ansible_connection=local ansible_python_interpreter=/path/to/bin/python3
+```
 
 ## References
 ### Terraform

--- a/ansible/amazon_create_secret.yml
+++ b/ansible/amazon_create_secret.yml
@@ -1,0 +1,34 @@
+---
+
+- name: Add Secrets in AWS Secrets Manager
+  hosts: localhost
+  # connection: local
+  vars:
+    aws_region: us-east-2
+    secrets_list:
+      - {secret_name: "DEFCON_2023_OBSIDIAN-cribl-admin-pass",
+         secret_string: "[REDACTED]"
+      }
+      - {secret_name: "DEFCON_2023_OBSIDIAN-securityonion-admin-pass",
+         secret_string: "[REDACTED]"
+      }
+      - {secret_name: "DEFCON_2023_OBSIDIAN-securityonion-soremote-pass",
+         secret_string: "[REDACTED]"
+      }
+      - {secret_name: "DEFCON_2023_OBSIDIAN-securityonion-webuser-pass",
+         secret_string: "[REDACTED]"
+      }
+      - {secret_name: "DEFCON_2023_OBSIDIAN-breakglass-pass",
+         secret_string: "[REDACTED]"
+      }
+  tasks:
+    - name: Add string to AWS Secrets Manager
+      community.aws.secretsmanager_secret:
+        name: "{{ item.secret_name }}"
+        state: present
+        secret_type: 'string'
+        secret: "{{ item.secret_string }}"
+        region: "{{ aws_region }}"
+        tags:
+          Project: DEFCON_2023_OBSIDIAN
+      loop: "{{ secrets_list2 }}"

--- a/ansible/amazon_list.yml
+++ b/ansible/amazon_list.yml
@@ -1,0 +1,34 @@
+---
+
+- name: Test/List AWS resources
+  hosts: localhost
+  vars:
+    aws_region: us-east-2
+  tasks:
+    - name: Gather information about all EC2 instances
+      amazon.aws.ec2_instance_info:
+        region: "{{ aws_region }}"
+        filters:
+          "tag:Project": DEFCON_2023_OBSIDIAN
+      register: ec2_info
+    - name: Debug | EC2 instances info
+      ansible.builtin.debug:
+        var: ec2_info
+        verbosity: 1
+    - name: Gather information about all S3 buckets
+      community.aws.s3_bucket_info:
+      register: s3_info
+    - name: Debug | S3 instancess info
+      ansible.builtin.debug:
+        var: s3_info
+        verbosity: 1
+    - name: Retrieve a list of objects in S3 bucket
+      amazon.aws.s3_object_info:
+        bucket_name: defcon-2023-obsidian-teleport-kxl6y
+      register: s3_info1
+      when: false
+    - name: Debug | S3 info
+      ansible.builtin.debug:
+        var: s3_info1
+        verbosity: 1
+      when: false

--- a/ansible/amazon_logging_off.yml
+++ b/ansible/amazon_logging_off.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Logging servers - Turn off
+  hosts: localhost
+  vars:
+    aws_region: us-east-2
+    instance_ids:
+      # cribl
+      - i-066a8274b56cea7ed
+      # security onion
+      - i-0b92af4ea521fc37e
+      # docker server
+      - i-0d53b41f01f817ac0
+      # velociraptor
+      - i-0355c0d71acb15ab0
+  tasks:
+    - name: Stop the logging servers
+      amazon.aws.ec2_instance:
+        instance_ids: "{{ item }}"
+        region: '{{ aws_region }}'
+        state: stopped
+        wait: true
+        # default wait is 600 seconds
+        wait_timeout: 30
+      loop: "{{ instance_ids }}"

--- a/ansible/amazon_logging_on.yml
+++ b/ansible/amazon_logging_on.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Logging servers - Turn on
+  hosts: localhost
+  vars:
+    aws_region: us-east-2
+    instance_ids:
+      # cribl
+      - i-066a8274b56cea7ed
+      # security onion
+      - i-0b92af4ea521fc37e
+      # docker server
+      - i-0d53b41f01f817ac0
+      # velociraptor
+      - i-0355c0d71acb15ab0
+  tasks:
+    - name: Start the logging servers
+      amazon.aws.ec2_instance:
+        instance_ids: "{{ item }}"
+        region: '{{ aws_region }}'
+        state: started
+        wait: true
+        # default wait is 600 seconds
+        wait_timeout: 30
+      loop: "{{ instance_ids }}"


### PR DESCRIPTION

# Background
Few ansible playbooks for maintenance operations: turn on/off logging servers, list ec2, create secrets
No functional impact on infrastructure outside of that.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Changes
seceng comfort :)

# Testing
all good