### PR TITLE
fix: pylint&co create_employees_passwords.py

### DIFF
--- a/ansible/conf/windows/domaincontroller/create_employees_passwords.py
+++ b/ansible/conf/windows/domaincontroller/create_employees_passwords.py
@@ -1,30 +1,38 @@
+"""
+Windows Active Directory users creations from csv
+"""
 # Import required libraries
 import csv
-import secrets, string
+import secrets
+import string
 
 # Configure variables
-input_employees = 'template_employees.csv'
-output_employees = 'employees.csv'
-password_length = 24
-password_characters = string.ascii_letters + string.digits
+INPUT_EMPLOYEES = "template_employees.csv"
+OUTPUT_EMPLOYEES = "employees.csv"
+PASSWORD_LENGTH = 24
+PASSWORD_CHARACTERS = string.ascii_letters + string.digits
 
 # Create 'password' column in new CSV file
 # - https://stackoverflow.com/questions/11070527/how-to-add-a-new-column-to-a-csv-file
 # - https://docs.python.org/3/library/secrets.html
-with open(input_employees, 'r') as csvInput, open(output_employees, 'w') as csvOutput:
-    csvWriter = csv.writer(csvOutput, lineterminator='\n')
+with open(INPUT_EMPLOYEES, "r", encoding="ascii") as csvInput, open(
+    OUTPUT_EMPLOYEES, "w", encoding="ascii"
+) as csvOutput:
+    csvWriter = csv.writer(csvOutput, lineterminator="\n")
     csvReader = csv.reader(csvInput)
 
     # Write first row with column headers to output file
-    all = []
+    allusers = []
     row = next(csvReader)
-    all.append(row)
+    allusers.append(row)
 
     # Check for empty cells in password column, add random passwords as needed
     for row in csvReader:
-        random_password = ''.join(secrets.choice(password_characters) for i in range(password_length))
+        RANDOM_PASSWORD = "".join(
+            secrets.choice(PASSWORD_CHARACTERS) for i in range(PASSWORD_LENGTH)
+        )
         if not row[7]:
-            row = row[:-1] # removes comma at end of row before appending password
-            row.append(random_password)
-        all.append(row)
-    csvWriter.writerows(all)
+            row = row[:-1]  # removes comma at end of row before appending password
+            row.append(RANDOM_PASSWORD)
+        allusers.append(row)
+    csvWriter.writerows(allusers)


### PR DESCRIPTION
# Background

This fixes python script linting that as a result makes a red flag in all pipelines precommit_test like
https://github.com/blueteamvillage/DC31-obsidian-sec-eng/actions/runs/4450153081/jobs/7815242488#step:5:56

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Changes

* pylint
* black
* flake8

# Testing
Provide output from tests
