### PR TITLE
fix missing network rule from cribl to splunk tcp/9997

### DIFF
--- a/terraform/public_subnet.tf
+++ b/terraform/public_subnet.tf
@@ -229,6 +229,7 @@ resource "aws_security_group_rule" "cribl_allow_http" {
   to_port     = 9000
   protocol    = "tcp"
   cidr_blocks = [
+    "${module.teleport.private_ip_addr}/32",
     # cribl needs to call itself
     "${aws_eip.cribl_server_eip.public_ip}/32",
     var.corp_cidr_block,
@@ -313,6 +314,19 @@ resource "aws_security_group" "splunk_server_sg" {
     to_port     = 22
     protocol    = "tcp"
     cidr_blocks = ["${module.teleport.private_ip_addr}/32"]
+  }
+
+  # Splunk UI
+  ingress {
+    from_port = 8000
+    to_port   = 8000
+    protocol  = "tcp"
+    cidr_blocks = [
+      "${module.teleport.private_ip_addr}/32",
+      #var.publicCIDRblock,
+      #var.managementCIDRblock,
+      #"0.0.0.0/0"
+    ]
   }
 
   # NGINX HTTP port for Splunk UI


### PR DESCRIPTION
# Background
Missing network rule

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Changes
* add network rule between cribl and splunk

# Testing

Pending deployment
