### PR TITLE
Updates

### DIFF
--- a/terraform/iot_subnet.tf
+++ b/terraform/iot_subnet.tf
@@ -49,7 +49,7 @@ resource "aws_instance" "iot_plc_servers" {
   }
 
   ami           = var.ubunut-ami
-  instance_type = "t3.nano"
+  instance_type = "t3.micro"
   subnet_id     = aws_subnet.iot.id
   vpc_security_group_ids = [
     aws_security_group.iot_plc_servers.id,
@@ -123,6 +123,16 @@ resource "aws_security_group_rule" "allow_all_traffic_from_iot_subnet" {
   to_port           = 0
   protocol          = -1
   cidr_blocks       = [var.iot_cidr_block]
+  security_group_id = aws_security_group.iot_hmi_servers.id
+}
+
+resource "aws_security_group_rule" "allow_tomcat_from_teleport" {
+  type              = "ingress"
+  description       = "Allow Tomcat/ScadaBR from Teleport"
+  from_port         = 8080
+  to_port           = 8080
+  protocol          = "tcp"
+  cidr_blocks       = ["${module.teleport.private_ip_addr}/32"]
   security_group_id = aws_security_group.iot_hmi_servers.id
 }
 

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -14,3 +14,23 @@ resource "aws_route53_record" "securityonion" {
   ttl             = 300
   records         = [aws_eip.securityonion_server_eip.public_ip]
 }
+
+
+resource "aws_route53_record" "splunk" {
+  allow_overwrite = true
+  zone_id         = data.aws_route53_zone.project_route53_zone.zone_id
+  name            = "splunk.${var.project_base_domain}"
+  type            = "A"
+  ttl             = 300
+  records         = [aws_eip.splunk_server_eip.public_ip]
+}
+
+
+resource "aws_route53_record" "cribl" {
+  allow_overwrite = true
+  zone_id         = data.aws_route53_zone.project_route53_zone.zone_id
+  name            = "cribl.${var.project_base_domain}"
+  type            = "A"
+  ttl             = 300
+  records         = [aws_eip.cribl_server_eip.public_ip]
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -73,11 +73,12 @@ variable "logging_cidr_block" {
 variable "logging_subnet_map" {
   type = map(string)
   default = {
-    "cribl"              = "172.16.22.10",
-    "splunk"             = "172.16.22.20",
-    "securityonion"      = "172.16.22.23",
-    "securityonion_bind" = "172.16.22.24",
-    "velociraptor"       = "172.16.22.130",
+    "cribl"                       = "172.16.22.10",
+    "splunk"                      = "172.16.22.20",
+    "securityonion"               = "172.16.22.23",
+    "securityonion_bind"          = "172.16.22.24",
+    "securityonion_bind_overflow" = "172.16.22.25",
+    "velociraptor"                = "172.16.22.130",
   }
 }
 


### PR DESCRIPTION
# Background
Provide any necessary background to the approver

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes
- Changed iot plc server types from `t3.nano` to `t3.micro`
- Added security group rule to allow tomcat access for teleport
- Added a SECOND TAP interface for SecurityOnion. Only instances can be monitored per interface. The second interface will handle all the remaining machines which is mostly PLCs.
   - created new `aws_ec2_traffic_mirror_target` named `seconion_overflow_traffic_mirror_target`
   - Added a new bind IP address
- Change instance type for SO
- Updated target mirror target for PLCs
- Added route53 records for all the logging servers

# Testing
It's in prod, just small changes
