### PR TITLE
fix: add /var/log/syslog to filebeat - not matching existing pattern

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -27,6 +27,9 @@ filebeat_inputs:
       - "/var/log/*.log"
   - type: log
     paths:
+      - "/var/log/syslog"
+  - type: log
+    paths:
       - "/var/log/osquery/osqueryd.*.log"
   - type: log
     paths:


### PR DESCRIPTION
# Background
as above
probably want to switch to journalctl ingestion next year (or sooner?)
https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-journald.html

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes
* add /var/log/syslog

# Testing
already pushed to iotpc and corp docker servers