### PR TITLE
fix: add allow inbound from nat gateway to velociraptor server

### DIFF
--- a/terraform/public_subnet.tf
+++ b/terraform/public_subnet.tf
@@ -8,6 +8,19 @@ resource "aws_security_group" "velociraptor_server_sg2" {
   }
 }
 
+# This is what allow client traffic to move out and reach back velociraptor server with public access blocked.
+resource "aws_security_group_rule" "allow_inbound_from_nat_gateway" {
+  type        = "ingress"
+  description = "Allow all traffic from NAT gateway for velociraptor server"
+  from_port   = 0
+  to_port     = 0
+  protocol    = -1
+  cidr_blocks = [
+    "${module.vpc.nat_public_ips[0]}/32",
+  ]
+  security_group_id = aws_security_group.velociraptor_server_sg2.id
+}
+
 resource "aws_security_group_rule" "velociraptor_allow_http" {
   type        = "ingress"
   description = "Allow HTTP from jumpbox, corp + dmz subnets, web server, and corp subnet NAT gateway for Velociraptor networking"


### PR DESCRIPTION
# Background
Add allow inbound from nat gateway to velociraptor server
based on https://github.com/blueteamvillage/DC31-obsidian-sec-eng/blob/main/terraform/red_team_subnet.tf#L24

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Changes

* add network rules to allow traffic from velociraptor client to velociraptor server but "passing through public Internet" even if general Internet is blocked and used same public dns.

# Testing
pending deployment