### PR TITLE
fix: cribl api pass in aws_secrets, missing hosts.ini entry

### DIFF
--- a/ansible/group_vars/cribl_server/main.yml
+++ b/ansible/group_vars/cribl_server/main.yml
@@ -2,6 +2,7 @@
 
 # TODO: add btv one
 # cribl_license_dat: cribl-license.dat
+cribl_api_password: "{{ lookup('amazon.aws.aws_secret', 'DEFCON_2023_OBSIDIAN-cribl-api-pass', region=aws_region) }}"
 
 cribl_fqdn: "cribl.{{ external_domain }}"
 
@@ -18,6 +19,8 @@ hardenwebserver_ssl_key: "/etc/letsencrypt/live/{{ cribl_fqdn }}/privkey.pem"
 hardenwebserver_systemd_dir_acl:
   - { p: /etc/letsencrypt/archive, perm: rx, m: '0711' }
   - { p: /etc/letsencrypt/live, perm: rx, m: '0711' }
+  - { p: "/etc/ssl/private", perm: rx, m: '0710' }
   - { p: "/var/log/nginx", perm: rwx, m: '0755' }
 hardenwebserver_systemd_files_acl:
   - { p: "/etc/letsencrypt/live/{{ cribl_fqdn }}/privkey.pem", perm: r }
+  - { p: "/etc/ssl/private/dhparam4.pem", perm: r }

--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -10,6 +10,9 @@ ip-172-16-10-93.teleport.blueteamvillage.com ansible_user=ubuntu
 [metrics_server]
 ip-172-16-21-10.teleport.blueteamvillage.com ansible_user=ubuntu
 
+[cribl_server]
+ip-172-16-22-10.teleport.blueteamvillage.com ansible_user=ubuntu
+
 [security_onion]
 ip-172-16-22-23.teleport.blueteamvillage.com ansible_user=ubuntu
 


### PR DESCRIPTION
# Background
cribl api pass in aws_secrets, missing hosts.ini entry

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
## Changes

* cribl api pass in aws_secrets
* missing hosts.ini entry

# Testing
already deployed with ansible
