### PR TITLE
splunk ansible: create multiple search indexes and HEC inputs

### DIFF
--- a/ansible/deploy_splunk.yml
+++ b/ansible/deploy_splunk.yml
@@ -32,5 +32,28 @@
     - splunk_standalone
     - juju4.harden_nginx
     - node_exporter
+  handlers:
+    - name: Restart Splunkd
+      ansible.builtin.service:
+        name: Splunkd
+        state: restarted
   tasks:
     - import_tasks: 'roles/linux/init_linux.yml'
+    - name: Set multiple Splunk indexes
+      ansible.builtin.template:
+        src: splunk-indexes.conf.j2
+        dest: /opt/splunk/etc/apps/search/local/indexes.conf
+        mode: 0600
+        owner: splunk
+        group: splunk
+      notify:
+        - Restart Splunkd
+    - name: Set multiple Splunk HEC inputs attached to separate index
+      ansible.builtin.template:
+        src: splunk-inputs.conf.j2
+        dest: /opt/splunk/etc/apps/search/local/inputs.conf
+        mode: 0600
+        owner: splunk
+        group: splunk
+      notify:
+        - Restart Splunkd

--- a/ansible/group_vars/splunk/main.yml
+++ b/ansible/group_vars/splunk/main.yml
@@ -63,6 +63,7 @@ splunk:
     httpinput: /opt/splunk/etc/apps/splunk_httpinput
     idxc: /opt/splunk/etc/master-apps
     shc: /opt/splunk/etc/shcluster/apps
+  # how to make multiple hec and associate to index?
   hec:
     # seems applied even if enable False...
     enable: True

--- a/ansible/templates/splunk-indexes.conf.j2
+++ b/ansible/templates/splunk-indexes.conf.j2
@@ -1,0 +1,50 @@
+{{ ansible_managed | comment }}
+# /opt/splunk/etc/apps/search/local/indexes.conf
+
+[osquery]
+coldPath = $SPLUNK_DB/osquery/colddb
+enableDataIntegrityControl = 0
+enableTsidxReduction = 0
+homePath = $SPLUNK_DB/osquery/db
+maxTotalDataSizeMB = 512000
+thawedPath = $SPLUNK_DB/osquery/thaweddb
+
+[syslog]
+coldPath = $SPLUNK_DB/syslog/colddb
+enableDataIntegrityControl = 0
+enableTsidxReduction = 0
+homePath = $SPLUNK_DB/syslog/db
+maxTotalDataSizeMB = 512000
+thawedPath = $SPLUNK_DB/syslog/thaweddb
+
+[sysmonforlinux]
+coldPath = $SPLUNK_DB/sysmonforlinux/colddb
+enableDataIntegrityControl = 0
+enableTsidxReduction = 0
+homePath = $SPLUNK_DB/sysmonforlinux/db
+maxTotalDataSizeMB = 512000
+thawedPath = $SPLUNK_DB/sysmonforlinux/thaweddb
+
+[sysmon]
+coldPath = $SPLUNK_DB/sysmon/colddb
+enableDataIntegrityControl = 0
+enableTsidxReduction = 0
+homePath = $SPLUNK_DB/sysmon/db
+maxTotalDataSizeMB = 512000
+thawedPath = $SPLUNK_DB/sysmon/thaweddb
+
+[linux]
+coldPath = $SPLUNK_DB/linux/colddb
+enableDataIntegrityControl = 0
+enableTsidxReduction = 0
+homePath = $SPLUNK_DB/linux/db
+maxTotalDataSizeMB = 512000
+thawedPath = $SPLUNK_DB/linux/thaweddb
+
+[windows]
+coldPath = $SPLUNK_DB/windows/colddb
+enableDataIntegrityControl = 0
+enableTsidxReduction = 0
+homePath = $SPLUNK_DB/windows/db
+maxTotalDataSizeMB = 512000
+thawedPath = $SPLUNK_DB/windows/thaweddb

--- a/ansible/templates/splunk-inputs.conf.j2
+++ b/ansible/templates/splunk-inputs.conf.j2
@@ -1,0 +1,61 @@
+{{ ansible_managed | comment }}
+# /opt/splunk/etc/apps/search/local/inputs.conf
+
+# Data input > TCP
+[tcp://9514]
+connection_host = dns
+host = {{ ansible_hostname }}
+index = syslog
+sourcetype = syslog
+disabled = 1
+
+[splunktcp://9525]
+connection_host = ip
+
+[http://splunk_hec_token_linux]
+description = Linux logs
+disabled = 0
+host = {{ ansible_hostname }}
+index = linux
+indexes = linux
+source = linux
+sourcetype = linux_messages_syslog
+token = REDACTED
+
+[http://splunk_hec_token_osquery]
+description = osquery linux
+disabled = 0
+host = {{ ansible_hostname }}
+index = osquery
+indexes = osquery
+source = osquery
+sourcetype = osquery:results
+token = REDACTED
+
+[http://splunk_hec_token_sysmonforlinux]
+description = sysmonforlinux
+disabled = 0
+host = {{ ansible_hostname }}
+index = sysmonforlinux
+indexes = sysmonforlinux
+source = sysmonforlinux
+sourcetype = sysmon_linux
+token = REDACTED
+
+[http://splunk_hec_token_windows]
+description = windows event logs
+disabled = 0
+host = {{ ansible_hostname }}
+index = windows
+indexes = windows
+source = windows
+token = REDACTED
+
+[http://splunk_hec_token_sysmon]
+description = sysmon windows
+disabled = 0
+host = {{ ansible_hostname }}
+index = sysmon
+indexes = sysmon
+source = sysmon
+token = REDACTED


### PR DESCRIPTION
# Background
create multiple search indexes and HEC inputs to support https://github.com/blueteamvillage/DC31-obsidian-sec-eng/issues/101

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes

* update splunk indexes and inputs with linux, osquery, sysmonforlinux, windows, sysmon as Splunk HEC

# Testing
Change already lived from my testing.
Just aligning playbook with it.
Not tested and likely don't want to test on current instance with approaching KC execution.

Note that tokens have been redacted and should be replace by unique values, probably from aws_secrets but can be reviewed later.
