### PR TITLE
fix: missing cribl to splunk rules, tcp/9997 and tcp/8088

### DIFF
--- a/terraform/public_subnet.tf
+++ b/terraform/public_subnet.tf
@@ -400,6 +400,32 @@ resource "aws_security_group_rule" "splunk_allow_rest_api" {
   security_group_id = aws_security_group.splunk_server_sg.id
 }
 
+resource "aws_security_group_rule" "cribl2splunkhec_allow" {
+  type        = "ingress"
+  description = "Allow access from Cribl to Splunk HEC"
+  from_port   = 8088
+  to_port     = 8088
+  protocol    = "tcp"
+  cidr_blocks = [
+    "${module.teleport.private_ip_addr}/32",
+    "${var.logging_subnet_map["cribl"]}/32",
+  ]
+  security_group_id = aws_security_group.splunk_server_sg.id
+}
+
+resource "aws_security_group_rule" "cribl2splunk_allow" {
+  type        = "ingress"
+  description = "Allow access from Cribl to Splunk Receiver"
+  from_port   = 9997
+  to_port     = 9997
+  protocol    = "tcp"
+  cidr_blocks = [
+    "${module.teleport.private_ip_addr}/32",
+    "${var.logging_subnet_map["cribl"]}/32",
+  ]
+  security_group_id = aws_security_group.splunk_server_sg.id
+}
+
 resource "aws_security_group_rule" "splunk_allow_prometheus" {
   type              = "ingress"
   description       = "Allow prometheus to pull metrics from node exporter"


### PR DESCRIPTION
# Background
add missing network rules.
those are already deployed/live.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes

* terraform network rules between cribl and splunk, receiver tcp/9997, splunk hec tcp/8088 (last one allowing index split)

# Testing
already live
