### PR TITLE
Pin aws/vpc module version

### DIFF
--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,6 +1,7 @@
 ############################################# Create VPC ############################################
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
+  version = "4.0.1"
 
   name = "${var.PROJECT_PREFIX}_VPC"
   cidr = var.vpc_cidr_block


### PR DESCRIPTION
# Background
We are using the `aws/vpc` module but we didn't pin a version. So terraform magically auto updated that module and everything broke.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Changes
- Pinned a version for `aws/vpc` module

# Testing
```
➜  terraform git:(vpc-pin-version) ✗ AWS_PROFILE=cth_bdb terraform init

Initializing the backend...
Initializing modules...

Initializing provider plugins...
- Reusing previous version of hashicorp/aws from the dependency lock file
- Reusing previous version of hashicorp/random from the dependency lock file
- Reusing previous version of hashicorp/template from the dependency lock file
- Installing hashicorp/aws v4.51.0...
- Installed hashicorp/aws v4.51.0 (signed by HashiCorp)
- Installing hashicorp/random v3.4.3...
- Installed hashicorp/random v3.4.3 (signed by HashiCorp)
- Installing hashicorp/template v2.2.0...
- Installed hashicorp/template v2.2.0 (signed by HashiCorp)

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
```
