### PR TITLE
Change TF version pin

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 terraform {
-  required_version = "~>1.3.7"
+  required_version = ">= 1.3.7"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
# Background
TF code was pinned to TF v1.3.7 which doesn't allow newer versions of TF. This PR changes this constraint to allow newer versions.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Changes
Change TF version constraint from `~> 1.3.7` to `=> 1.3.7`

# Testing
```
➜  terraform git:(tf-pinned-version)  terraform plan
module.teleport.random_string.suffix: Refreshing state... [id=pcq49]
module.teleport.random_string.bucket_suffix: Refreshing state... [id=kxl6y]
random_password.win_domain_admin_random_passwd_gen: Refreshing state... [id=none]
random_string.bucket_suffix: Refreshing state... [id=zkx4p]
data.template_file.password_change: Reading...
...
```